### PR TITLE
Fix late MSHR merges after cache fill

### DIFF
--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -547,35 +547,6 @@ bool was_writeallocate_sent(const std::list<cache_event> &events) {
   }
   return false;
 }
-/****************************************************************** MSHR
- * ******************************************************************/
-
-/// Checks if there is a pending request to the lower memory level already
-bool mshr_table::probe(new_addr_type block_addr) const {
-  table::const_iterator a = m_data.find(block_addr);
-  return a != m_data.end();
-}
-
-/// Checks if there is space for tracking a new memory access
-bool mshr_table::full(new_addr_type block_addr) const {
-  table::const_iterator i = m_data.find(block_addr);
-  if (i != m_data.end())
-    return i->second.m_list.size() >= m_max_merged;
-  else
-    return m_data.size() >= m_num_entries;
-}
-
-/// Add or merge this access
-void mshr_table::add(new_addr_type block_addr, mem_fetch *mf) {
-  m_data[block_addr].m_list.push_back(mf);
-  assert(m_data.size() <= m_num_entries);
-  assert(m_data[block_addr].m_list.size() <= m_max_merged);
-  // indicate that this MSHR entry contains an atomic operation
-  if (mf->isatomic()) {
-    m_data[block_addr].m_has_atomic = true;
-  }
-}
-
 /// check is_read_after_write_pending
 bool mshr_table::is_read_after_write_pending(new_addr_type block_addr) {
   std::list<mem_fetch *> my_list = m_data[block_addr].m_list;
@@ -589,31 +560,6 @@ bool mshr_table::is_read_after_write_pending(new_addr_type block_addr) {
   }
 
   return false;
-}
-
-/// Accept a new cache fill response: mark entry ready for processing
-void mshr_table::mark_ready(new_addr_type block_addr, bool &has_atomic) {
-  assert(!busy());
-  table::iterator a = m_data.find(block_addr);
-  assert(a != m_data.end());
-  m_current_response.push_back(block_addr);
-  has_atomic = a->second.m_has_atomic;
-  assert(m_current_response.size() <= m_data.size());
-}
-
-/// Returns next ready access
-mem_fetch *mshr_table::next_access() {
-  assert(access_ready());
-  new_addr_type block_addr = m_current_response.front();
-  assert(!m_data[block_addr].m_list.empty());
-  mem_fetch *result = m_data[block_addr].m_list.front();
-  m_data[block_addr].m_list.pop_front();
-  if (m_data[block_addr].m_list.empty()) {
-    // release entry
-    m_data.erase(block_addr);
-    m_current_response.pop_front();
-  }
-  return result;
 }
 
 void mshr_table::display(FILE *fp) const {
@@ -1450,13 +1396,21 @@ void baseline_cache::send_read_request(new_addr_type addr,
   new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
   bool mshr_hit = m_mshrs.probe(mshr_addr);
   bool mshr_avail = !m_mshrs.full(mshr_addr);
-  if (mshr_hit && mshr_avail) {
+  bool ready_forward =
+      m_mshrs.ready_for_forward(mshr_addr) && !wa && !mf->isatomic();
+  if (ready_forward) {
+    // The lower-level response has arrived but older merged accesses are still
+    // draining. Forward that response without allocating another cache line.
+    m_mshrs.add_ready(mshr_addr, mf);
+    m_stats.inc_stats(mf->get_access_type(), MSHR_HIT, mf->get_streamID());
+    do_miss = true;
+  } else if (mshr_hit && mshr_avail) {
     if (read_only)
       m_tag_array->access(block_addr, time, cache_index, mf);
     else
       m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
 
-    m_mshrs.add(mshr_addr, mf);
+    m_mshrs.add(mshr_addr, mf, mf->isatomic());
     m_stats.inc_stats(mf->get_access_type(), MSHR_HIT, mf->get_streamID());
     do_miss = true;
 
@@ -1467,7 +1421,7 @@ void baseline_cache::send_read_request(new_addr_type addr,
     else
       m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
 
-    m_mshrs.add(mshr_addr, mf);
+    m_mshrs.add(mshr_addr, mf, mf->isatomic());
     m_extra_mf_fields[mf] = extra_mf_fields(
         mshr_addr, mf->get_addr(), cache_index, mf->get_data_size(), m_config);
     mf->set_data_size(m_config.get_atom_sz());
@@ -1477,7 +1431,7 @@ void baseline_cache::send_read_request(new_addr_type addr,
     if (!wa) events.push_back(cache_event(READ_REQUEST_SENT));
 
     do_miss = true;
-  } else if (mshr_hit && !mshr_avail)
+  } else if ((mshr_hit && !mshr_avail) || m_mshrs.probe_ready(mshr_addr))
     m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL,
                            mf->get_streamID());
   else if (!mshr_hit && !mshr_avail)

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -1035,10 +1035,16 @@ class mshr_table {
 
   /// Checks if there is a pending request to the lower memory level already
   bool probe(new_addr_type block_addr) const;
+  /// Checks if a returned request is still draining merged accesses
+  bool probe_ready(new_addr_type block_addr) const;
+  /// Checks if a late read can consume the response being drained
+  bool ready_for_forward(new_addr_type block_addr) const;
   /// Checks if there is space for tracking a new memory access
   bool full(new_addr_type block_addr) const;
   /// Add or merge this access
-  void add(new_addr_type block_addr, mem_fetch *mf);
+  void add(new_addr_type block_addr, mem_fetch *mf, bool is_atomic);
+  /// Append a late read to an entry whose response has already arrived
+  void add_ready(new_addr_type block_addr, mem_fetch *mf);
   /// Returns true if cannot accept new fill responses
   bool busy() const { return false; }
   /// Accept a new cache fill response: mark entry ready for processing
@@ -1067,7 +1073,8 @@ class mshr_table {
   struct mshr_entry {
     std::list<mem_fetch *> m_list;
     bool m_has_atomic;
-    mshr_entry() : m_has_atomic(false) {}
+    bool m_ready;
+    mshr_entry() : m_has_atomic(false), m_ready(false) {}
   };
   typedef tr1_hash_map<new_addr_type, mshr_entry> table;
   typedef tr1_hash_map<new_addr_type, mshr_entry> line_table;

--- a/src/gpgpu-sim/mshr-table.cc
+++ b/src/gpgpu-sim/mshr-table.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2009-2021, Tor M. Aamodt, Tayler Hetherington,
+// Vijay Kandiah, Nikos Hardavellas, Mahmoud Khairy, Junrui Pan,
+// Timothy G. Rogers
+// The University of British Columbia, Northwestern University, Purdue
+// University All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer;
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution;
+// 3. Neither the names of The University of British Columbia, Northwestern
+//    University nor the names of their contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "gpu-cache.h"
+
+bool mshr_table::probe(new_addr_type block_addr) const {
+  table::const_iterator entry = m_data.find(block_addr);
+  return entry != m_data.end() && !entry->second.m_ready;
+}
+
+bool mshr_table::probe_ready(new_addr_type block_addr) const {
+  table::const_iterator entry = m_data.find(block_addr);
+  return entry != m_data.end() && entry->second.m_ready;
+}
+
+bool mshr_table::ready_for_forward(new_addr_type block_addr) const {
+  table::const_iterator entry = m_data.find(block_addr);
+  return entry != m_data.end() && entry->second.m_ready &&
+         entry->second.m_list.size() < m_max_merged;
+}
+
+bool mshr_table::full(new_addr_type block_addr) const {
+  table::const_iterator entry = m_data.find(block_addr);
+  if (entry != m_data.end() && entry->second.m_ready)
+    return true;
+  else if (entry != m_data.end())
+    return entry->second.m_list.size() >= m_max_merged;
+  else
+    return m_data.size() >= m_num_entries;
+}
+
+void mshr_table::add(new_addr_type block_addr, mem_fetch *mf, bool is_atomic) {
+  assert(!probe_ready(block_addr));
+  m_data[block_addr].m_list.push_back(mf);
+  assert(m_data.size() <= m_num_entries);
+  assert(m_data[block_addr].m_list.size() <= m_max_merged);
+  if (is_atomic) m_data[block_addr].m_has_atomic = true;
+}
+
+void mshr_table::add_ready(new_addr_type block_addr, mem_fetch *mf) {
+  assert(ready_for_forward(block_addr));
+  m_data[block_addr].m_list.push_back(mf);
+}
+
+void mshr_table::mark_ready(new_addr_type block_addr, bool &has_atomic) {
+  assert(!busy());
+  table::iterator entry = m_data.find(block_addr);
+  assert(entry != m_data.end());
+  assert(!entry->second.m_ready);
+  entry->second.m_ready = true;
+  m_current_response.push_back(block_addr);
+  has_atomic = entry->second.m_has_atomic;
+  assert(m_current_response.size() <= m_data.size());
+}
+
+mem_fetch *mshr_table::next_access() {
+  assert(access_ready());
+  new_addr_type block_addr = m_current_response.front();
+  assert(!m_data[block_addr].m_list.empty());
+  mem_fetch *result = m_data[block_addr].m_list.front();
+  m_data[block_addr].m_list.pop_front();
+  if (m_data[block_addr].m_list.empty()) {
+    m_data.erase(block_addr);
+    m_current_response.pop_front();
+  }
+  return result;
+}

--- a/test/make/sm120.mk
+++ b/test/make/sm120.mk
@@ -14,11 +14,13 @@ UNIT_OBJ_DIR = $(OBJ_DIR)/unit
 INTEGRATION_OBJ_DIR = $(OBJ_DIR)/integration
 INTEGRATION_MMA_OBJ_DIR = $(OBJ_DIR)/integration/mma
 FLASH_OBJ_DIR = $(OBJ_DIR)/flash
+GPGPUSIM_OBJ_DIR = $(OBJ_DIR)/gpgpu-sim
 
 # bulk_group_test exercises this implementation directly.
 FLASH_SOURCES = $(SRC_DIR)/gpgpu-sim/flash/bulk_group.cc
 FLASH_OBJECTS = $(OBJ_DIR)/flash/bulk_group.cu.o
 LOCAL_INTERCONNECT_OBJECT = $(OBJ_DIR)/unit/local_interconnect.cc.o
+MSHR_TABLE_OBJECT = $(GPGPUSIM_OBJ_DIR)/mshr-table.cu.o
 
 .PHONY: test-sm120-unit test-sm120-integration
 
@@ -26,7 +28,8 @@ test-sm120-unit: setup-gtest $(SM120_UNIT_TARGET)
 
 test-sm120-integration: setup-gtest $(SM120_INTEGRATION_TARGET)
 
-$(UNIT_OBJ_DIR) $(INTEGRATION_OBJ_DIR) $(INTEGRATION_MMA_OBJ_DIR) $(FLASH_OBJ_DIR):
+$(UNIT_OBJ_DIR) $(INTEGRATION_OBJ_DIR) $(INTEGRATION_MMA_OBJ_DIR) \
+$(FLASH_OBJ_DIR) $(GPGPUSIM_OBJ_DIR):
 	mkdir -p $@
 
 $(OBJ_DIR)/flash/%.cu.o: $(SRC_DIR)/gpgpu-sim/flash/%.cc \
@@ -41,13 +44,17 @@ $(LOCAL_INTERCONNECT_OBJECT): $(SRC_DIR)/gpgpu-sim/local_interconnect.cc \
 $(SRC_DIR)/gpgpu-sim/local_interconnect.h $(TOP_MAKEFILE) $(SM120_MK) | $(UNIT_OBJ_DIR)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $(GPGPUSIM_FLAGS) -c $< -o $@
 
+$(MSHR_TABLE_OBJECT): $(SRC_DIR)/gpgpu-sim/mshr-table.cc \
+$(SRC_DIR)/gpgpu-sim/gpu-cache.h $(TOP_MAKEFILE) $(SM120_MK) | $(GPGPUSIM_OBJ_DIR)
+	$(NVCC) $(NVCCFLAGS) $(INCLUDES) $(GPGPUSIM_FLAGS) -c $< -o $@
+
 $(OBJ_DIR)/integration/%.cu.o: $(TEST_SRC_DIR)/integration/%.cc \
 $(CUH_HEADERS) $(TOP_MAKEFILE) $(SM120_MK)
 	@mkdir -p $(dir $@)
 	$(NVCC) $(NVCCFLAGS) $(INCLUDES) $(GPGPUSIM_FLAGS) -c $< -o $@
 
 $(SM120_UNIT_TARGET): $(UNIT_TEST_OBJECTS) $(FLASH_OBJECTS) \
-$(LOCAL_INTERCONNECT_OBJECT) \
+$(LOCAL_INTERCONNECT_OBJECT) $(MSHR_TABLE_OBJECT) \
 $(OBJ_DIR)/gtest_main.a $(TOP_MAKEFILE) $(SM120_MK) | $(BIN_DIR)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(filter-out $(TOP_MAKEFILE) $(SM120_MK),$^) \

--- a/test/src/unit/mshr_table_test.cc
+++ b/test/src/unit/mshr_table_test.cc
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include "../../../src/gpgpu-sim/gpu-cache.h"
+
+namespace {
+
+mem_fetch *fake_request(unsigned long &storage) {
+  return reinterpret_cast<mem_fetch *>(&storage);
+}
+
+TEST(MshrTableTest, PendingEntryAcceptsMergedAccesses) {
+  mshr_table table(/*num_entries=*/2, /*max_merged=*/4);
+  unsigned long first_storage = 0;
+  unsigned long second_storage = 0;
+  mem_fetch *first = fake_request(first_storage);
+  mem_fetch *second = fake_request(second_storage);
+  constexpr new_addr_type address = 0x1000;
+
+  table.add(address, first, /*is_atomic=*/false);
+  ASSERT_TRUE(table.probe(address));
+  EXPECT_FALSE(table.probe_ready(address));
+  EXPECT_FALSE(table.full(address));
+
+  table.add(address, second, /*is_atomic=*/false);
+  EXPECT_FALSE(table.full(address));
+}
+
+TEST(MshrTableTest, LateReadJoinsDrainingResponse) {
+  mshr_table table(/*num_entries=*/2, /*max_merged=*/4);
+  unsigned long first_storage = 0;
+  unsigned long second_storage = 0;
+  unsigned long late_storage = 0;
+  mem_fetch *first = fake_request(first_storage);
+  mem_fetch *second = fake_request(second_storage);
+  mem_fetch *late = fake_request(late_storage);
+  constexpr new_addr_type address = 0x2000;
+
+  table.add(address, first, /*is_atomic=*/false);
+  table.add(address, second, /*is_atomic=*/false);
+
+  bool has_atomic = true;
+  table.mark_ready(address, has_atomic);
+  ASSERT_FALSE(has_atomic);
+  EXPECT_FALSE(table.probe(address));
+  ASSERT_TRUE(table.probe_ready(address));
+  ASSERT_TRUE(table.ready_for_forward(address));
+
+  EXPECT_EQ(table.next_access(), first);
+  ASSERT_TRUE(table.probe_ready(address));
+
+  table.add_ready(address, late);
+  EXPECT_EQ(table.next_access(), second);
+  EXPECT_EQ(table.next_access(), late);
+  EXPECT_FALSE(table.access_ready());
+  EXPECT_FALSE(table.probe(address));
+  EXPECT_FALSE(table.probe_ready(address));
+}
+
+TEST(MshrTableTest, FullDrainingEntryRejectsLateForward) {
+  mshr_table table(/*num_entries=*/1, /*max_merged=*/2);
+  unsigned long first_storage = 0;
+  unsigned long second_storage = 0;
+  mem_fetch *first = fake_request(first_storage);
+  mem_fetch *second = fake_request(second_storage);
+  constexpr new_addr_type address = 0x3000;
+
+  table.add(address, first, /*is_atomic=*/false);
+  table.add(address, second, /*is_atomic=*/false);
+
+  bool has_atomic = false;
+  table.mark_ready(address, has_atomic);
+  EXPECT_TRUE(table.probe_ready(address));
+  EXPECT_FALSE(table.ready_for_forward(address));
+  EXPECT_TRUE(table.full(address));
+}
+
+TEST(MshrTableTest, AtomicStateIsReportedWhenResponseArrives) {
+  mshr_table table(/*num_entries=*/1, /*max_merged=*/2);
+  unsigned long storage = 0;
+  mem_fetch *request = fake_request(storage);
+  constexpr new_addr_type address = 0x4000;
+
+  table.add(address, request, /*is_atomic=*/true);
+
+  bool has_atomic = false;
+  table.mark_ready(address, has_atomic);
+  EXPECT_TRUE(has_atomic);
+}
+
+}  // namespace


### PR DESCRIPTION
## Problem

An MSHR entry remains in the table while its returned accesses drain one per cycle. The old `probe()` treated that ready/draining entry as an outstanding miss. If the filled cache line was evicted during this window, a later read could reserve a new cache line and merge into the already-completed MSHR. No lower-level request would refill the newly reserved line, leaving the cache permanently stuck.

## Fix

- Track pending and ready/draining MSHR states explicitly.
- For an ordinary late read, attach it directly to the draining response before touching the tag array. This performs no cache-line reservation and sends no duplicate lower-level request.
- Keep atomic and write-allocate requests on the retry path to preserve their ordering and modification semantics.
- Split the MSHR state-machine implementation into its own translation unit so it can be unit tested directly.

## Tests

- Added unit coverage for pending merges, late reads joining a draining response, merge-capacity limits, and atomic-state propagation.
- Full test suite: 144/144 passed.
- Full release simulator build with CUDA 12.8 passed.
- Reproducing sparse-GCN consumer case completed with deadlock detection enabled: 340/340 CTAs, 2,097,152/2,097,152 MMA operations, 504,572 cycles, exit status 0. The old implementation deadlocked after the late merge left reserved cache lines without a fill.