### PR TITLE
Add functional support for tensor TMA reduction stores

### DIFF
--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -5184,16 +5184,45 @@ extern "C" CUresult CUDAAPI cuTensorMapEncodeTiled(
 
   // Map CUDA API data type enum to internal TMA dtype constants
   switch (tensorDataType) {
-    case CU_TENSOR_MAP_DATA_TYPE_UINT8:    desc.fields.tensorDataType = TMA_DTYPE_U8;   break;
-    case CU_TENSOR_MAP_DATA_TYPE_UINT16:   desc.fields.tensorDataType = TMA_DTYPE_U16;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_UINT32:   desc.fields.tensorDataType = TMA_DTYPE_U32;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_INT32:    desc.fields.tensorDataType = TMA_DTYPE_U32;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_UINT64:   desc.fields.tensorDataType = TMA_DTYPE_U64;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_INT64:    desc.fields.tensorDataType = TMA_DTYPE_U64;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_FLOAT16:  desc.fields.tensorDataType = TMA_DTYPE_F16;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_FLOAT32:  desc.fields.tensorDataType = TMA_DTYPE_F32;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_FLOAT64:  desc.fields.tensorDataType = TMA_DTYPE_F64;  break;
-    case CU_TENSOR_MAP_DATA_TYPE_BFLOAT16: desc.fields.tensorDataType = TMA_DTYPE_BF16; break;
+    case CU_TENSOR_MAP_DATA_TYPE_UINT8:
+      desc.fields.tensorDataType = TMA_DTYPE_U8;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_UINT16:
+      desc.fields.tensorDataType = TMA_DTYPE_U16;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_UINT32:
+      desc.fields.tensorDataType = TMA_DTYPE_U32;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_INT32:
+      desc.fields.tensorDataType = TMA_DTYPE_S32;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_UINT64:
+      desc.fields.tensorDataType = TMA_DTYPE_U64;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_INT64:
+      desc.fields.tensorDataType = TMA_DTYPE_S64;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_FLOAT16:
+      desc.fields.tensorDataType = TMA_DTYPE_F16;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_FLOAT32:
+      desc.fields.tensorDataType = TMA_DTYPE_F32;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
+      desc.fields.tensorDataType = TMA_DTYPE_F64;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_BFLOAT16:
+      desc.fields.tensorDataType = TMA_DTYPE_BF16;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ:
+      desc.fields.tensorDataType = TMA_DTYPE_F32_FTZ;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_TFLOAT32:
+      desc.fields.tensorDataType = TMA_DTYPE_TF32;
+      break;
+    case CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
+      desc.fields.tensorDataType = TMA_DTYPE_TF32_FTZ;
+      break;
     default:
       printf("WARNING: cuTensorMapEncodeTiled: unsupported tensorDataType %d\n",
              (int)tensorDataType);

--- a/src/gpgpu-sim/flash/tensormap.cc
+++ b/src/gpgpu-sim/flash/tensormap.cc
@@ -46,12 +46,17 @@ uint32_t tensormap_descriptor_t::get_element_size() const {
   case TMA_DTYPE_U16:
     return 2;
   case TMA_DTYPE_U32:
+  case TMA_DTYPE_S32:
     return 4;
   case TMA_DTYPE_U64:
+  case TMA_DTYPE_S64:
     return 8;
   case TMA_DTYPE_F16:
     return 2;
   case TMA_DTYPE_F32:
+  case TMA_DTYPE_F32_FTZ:
+  case TMA_DTYPE_TF32:
+  case TMA_DTYPE_TF32_FTZ:
     return 4;
   case TMA_DTYPE_F64:
     return 8;

--- a/src/gpgpu-sim/flash/tensormap.h
+++ b/src/gpgpu-sim/flash/tensormap.h
@@ -14,11 +14,16 @@ class ptx_instruction;
 #define TMA_DTYPE_U8 0u
 #define TMA_DTYPE_U16 1u
 #define TMA_DTYPE_U32 2u
+#define TMA_DTYPE_S32 3u
 #define TMA_DTYPE_U64 4u
+#define TMA_DTYPE_S64 5u
 #define TMA_DTYPE_F16 6u
 #define TMA_DTYPE_F32 7u
-#define TMA_DTYPE_F64 9u
-#define TMA_DTYPE_BF16 10u
+#define TMA_DTYPE_F64 8u
+#define TMA_DTYPE_BF16 9u
+#define TMA_DTYPE_F32_FTZ 10u
+#define TMA_DTYPE_TF32 11u
+#define TMA_DTYPE_TF32_FTZ 12u
 
 // Interleave layout modes (in bytes)
 #define TMA_INTERLEAVE_NONE 0u

--- a/src/gpgpu-sim/flash/tma.cc
+++ b/src/gpgpu-sim/flash/tma.cc
@@ -1,5 +1,6 @@
 #include "tma.h"
 #include "tensormap.h"
+#include "tma_reduction.h"
 #include <algorithm>
 #include <atomic>
 #include <cstdarg>
@@ -2223,11 +2224,11 @@ static tma_oob_fill_table_t g_oob_fill_table;
 
 // Execute TMA data transfer (load or store)
 // is_load=true: global -> shared, is_load=false: shared -> global
-static void do_tma_transfer(const tensormap_descriptor_t &tensormap,
-                            const int32_t coords[5], memory_space *shared_mem,
-                            memory_space *global_mem, uint32_t smem_addr,
-                            ptx_thread_info *thread, const ptx_instruction *pI,
-                            bool is_load) {
+static void do_tma_transfer(
+    const tensormap_descriptor_t &tensormap, const int32_t coords[5],
+    memory_space *shared_mem, memory_space *global_mem, uint32_t smem_addr,
+    ptx_thread_info *thread, const ptx_instruction *pI, bool is_load,
+    tma_reduction_op_t reduction_op = tma_reduction_op_t::NONE) {
   // For load operations, pre-fill the entire tile in shared memory with OOB
   // fill value
   if (is_load) {
@@ -2318,11 +2319,56 @@ static void do_tma_transfer(const tensormap_descriptor_t &tensormap,
         shared_mem->read(smem_addr + tile_offset, req_size, data_buffer);
       }
 
-      global_mem->write(global_req_addr, req_size, data_buffer, thread, pI);
+      if (reduction_op == tma_reduction_op_t::NONE) {
+        global_mem->write(global_req_addr, req_size, data_buffer, thread, pI);
+      } else {
+        const uint32_t element_size = tensormap.get_element_size();
+        if (req_size % element_size != 0) {
+          printf("TMA ERROR: tensor reduction request size %u is not a "
+                 "multiple of element size %u\n",
+                 req_size, element_size);
+          abort();
+        }
+        std::vector<uint8_t> destination(req_size);
+        global_mem->read(global_req_addr, req_size, destination.data());
+        apply_tma_tensor_reduction(reduction_op,
+                                   tensormap.fields.tensorDataType,
+                                   destination.data(), data_buffer, req_size);
+        global_mem->write(global_req_addr, req_size, destination.data(), thread,
+                          pI);
+      }
     }
 
     if (req_size > LOCAL_BUF_SIZE)
       delete[] data_buffer;
+  }
+}
+
+static tma_reduction_op_t decode_tma_reduction_op(const ptx_instruction *pI) {
+  switch (pI->get_atomic()) {
+  case 0:
+    return tma_reduction_op_t::NONE;
+  case ATOMIC_ADD:
+    return tma_reduction_op_t::ADD;
+  case ATOMIC_MIN:
+    return tma_reduction_op_t::MIN;
+  case ATOMIC_MAX:
+    return tma_reduction_op_t::MAX;
+  case ATOMIC_INC:
+    return tma_reduction_op_t::INC;
+  case ATOMIC_DEC:
+    return tma_reduction_op_t::DEC;
+  case ATOMIC_AND:
+    return tma_reduction_op_t::BIT_AND;
+  case ATOMIC_OR:
+    return tma_reduction_op_t::BIT_OR;
+  case ATOMIC_XOR:
+    return tma_reduction_op_t::BIT_XOR;
+  default:
+    printf("TMA ERROR: unsupported tensor reduction operation %u\n",
+           pI->get_atomic());
+    pI->print_insn();
+    abort();
   }
 }
 
@@ -2586,21 +2632,56 @@ static void handle_tma_tensor(ptx_instruction *pI, ptx_thread_info *thread) {
   using namespace flash_gpgpu_sim;
 
   const auto &options = pI->get_options();
-  if (options.size() != 5) {
-    for (auto op : options) {
-      GPPRINTF_INST_EXEC(TMA, "  option: %d\n", op);
+  int dim_option = 0;
+  int completion_option = 0;
+  std::vector<int> space_options;
+  for (auto op : options) {
+    switch (op) {
+    case DIM_1D_OPTION:
+    case DIM_2D_OPTION:
+    case DIM_3D_OPTION:
+    case DIM_4D_OPTION:
+    case DIM_5D_OPTION:
+      dim_option = op;
+      break;
+    case GLOBAL_OPTION:
+    case CTA_OPTION:
+    case CLUSTER_OPTION:
+      space_options.push_back(op);
+      break;
+    case TMA_MBAR_COMPLETE_BYTES:
+    case BULK_GROUP_OPTION:
+      completion_option = op;
+      break;
+    case TENSOR_OPTION:
+    case TILE_OPTION:
+    case L2_CACHE_HINT_OPTION:
+    case ATOMIC_ADD:
+    case ATOMIC_MIN:
+    case ATOMIC_MAX:
+    case ATOMIC_INC:
+    case ATOMIC_DEC:
+    case ATOMIC_AND:
+    case ATOMIC_OR:
+    case ATOMIC_XOR:
+      break;
+    default:
+      break;
     }
   }
-  assert(
-      options.size() >= 5 &&
-      "TMA tensor copy must have: TENSOR_OPTION, dim, dst, src, completion.");
 
-  auto option_iter = options.begin();
-  ++option_iter; // Skip TENSOR_OPTION
-  auto dim_option = *option_iter++;
-  auto dst_option = *option_iter++;
-  auto src_option = *option_iter++;
-  auto completion_option = *option_iter++;
+  if (dim_option == 0 || space_options.size() < 2 || completion_option == 0) {
+    printf("TMA ERROR: unsupported tensor TMA option list: ");
+    for (auto op : options)
+      printf("%d ", op);
+    printf("\n");
+    pI->print_insn();
+    abort();
+  }
+
+  auto dst_option = space_options[0];
+  auto src_option = space_options[1];
+  const tma_reduction_op_t reduction_op = decode_tma_reduction_op(pI);
 
   memory_space *shared_mem = thread->m_shared_mem;
   memory_space *global_mem = thread->get_global_memory();
@@ -2609,6 +2690,11 @@ static void handle_tma_tensor(ptx_instruction *pI, ptx_thread_info *thread) {
   if ((dst_option == CTA_OPTION || dst_option == CLUSTER_OPTION) &&
       src_option == GLOBAL_OPTION &&
       completion_option == TMA_MBAR_COMPLETE_BYTES) {
+    if (reduction_op != tma_reduction_op_t::NONE) {
+      printf("TMA ERROR: tensor reduction is only supported for stores\n");
+      pI->print_insn();
+      abort();
+    }
     // Tensor load: shared <- global
     auto dst_addr = get_operand_u32(thread, pI->dst());
     uint64_t tensormap_addr = get_operand_u64(thread, pI->src1());
@@ -2660,6 +2746,16 @@ static void handle_tma_tensor(ptx_instruction *pI, ptx_thread_info *thread) {
     setup_tensor_tma(global_mem, tensormap_addr, inst_dim,
                      pI->get_operands()[1], thread, tensormap, coords,
                      size_in_bytes);
+    if (reduction_op != tma_reduction_op_t::NONE &&
+        !tma_tensor_reduction_supported(reduction_op,
+                                        tensormap.fields.tensorDataType)) {
+      printf("TMA ERROR: tensor reduction %s does not support tensor-map "
+             "data type %u\n",
+             tma_reduction_op_name(reduction_op),
+             tensormap.fields.tensorDataType);
+      pI->print_insn();
+      abort();
+    }
 
     GPPRINTF_INST_EXEC(
         TMA, "TMA tensor store Extracted coordinates: [%d, %d, %d, %d, %d]\n",
@@ -2684,12 +2780,17 @@ static void handle_tma_tensor(ptx_instruction *pI, ptx_thread_info *thread) {
     pI->set_tma_dyn_info(thread->get_laneid(), tma_dyn_info);
 
     do_tma_transfer(tensormap, coords, shared_mem, global_mem, src_addr, thread,
-                    pI, false);
+                    pI, false, reduction_op);
 
     uint64_t base_dst_addr = tensormap.calculate_src_addr(coords);
     GPPRINTF_INST_EXEC(TMA,
-                       "Functional Sim: TMA tensor store dst=0x%llx, src=0x%x, "
-                       "size=%u, tensormap=0x%llx\n",
+                       "Functional Sim: TMA tensor store%s%s dst=0x%llx, "
+                       "src=0x%x, size=%u, tensormap=0x%llx\n",
+                       reduction_op == tma_reduction_op_t::NONE ? ""
+                                                                : " reduce.",
+                       reduction_op == tma_reduction_op_t::NONE
+                           ? ""
+                           : tma_reduction_op_name(reduction_op),
                        (unsigned long long)base_dst_addr, src_addr,
                        size_in_bytes, (unsigned long long)tensormap_addr);
 

--- a/src/gpgpu-sim/flash/tma.md
+++ b/src/gpgpu-sim/flash/tma.md
@@ -273,7 +273,7 @@ void cycle();
 
 #### `do_tma_transfer()`
 
-**Signature**: `static void do_tma_transfer(const tensormap_descriptor_t &tensormap, const int32_t coords[5], memory_space *shared_mem, memory_space *global_mem, uint64_t shared_addr, ptx_thread_info *thread, const ptx_instruction *pI, bool is_load)`
+**Signature**: `static void do_tma_transfer(const tensormap_descriptor_t &tensormap, const int32_t coords[5], memory_space *shared_mem, memory_space *global_mem, uint64_t shared_addr, ptx_thread_info *thread, const ptx_instruction *pI, bool is_load, tma_reduction_op_t reduction_op)`
 
 **Purpose**: Perform functional simulation of TMA transfer between global and shared memory.
 
@@ -285,6 +285,7 @@ void cycle();
 - `thread`: Thread context
 - `pI`: Instruction pointer (for error reporting)
 - `is_load`: True for load (global→shared), false for store (shared→global)
+- `reduction_op`: Optional element-wise reduction for tensor stores
 
 **Behavior**:
 1. Calculate global base address from coordinates and tensormap
@@ -297,6 +298,32 @@ void cycle();
 5. Verify all bytes transferred
 
 **Multi-Dimensional Support**: Handles 1D-5D tensors with proper coordinate-to-address mapping.
+
+### Tensor Reduction Stores
+
+`cp.reduce.async.bulk.tensor` uses the normal tensor-store address generation
+and reverse-swizzle path, then atomically reduces each shared-memory element
+into its corresponding global-memory element in functional simulation. The
+supported operation/type pairs follow the PTX ISA:
+
+- `add`: `u32`, `s32`, `u64`, `f16`, `bf16`, `f32`
+- `min`, `max`: `u32`, `s32`, `u64`, `s64`, `f16`, `bf16`
+- `inc`, `dec`: `u32`
+- `and`, `or`, `xor`: 32-bit and 64-bit integer tensor-map types
+
+`FLOAT32` preserves subnormal inputs and results, while `FLOAT32_FTZ` flushes
+them to signed zero. This distinction is preserved by both the host tensor-map
+encoder and the functional reduction path.
+
+Only the `.tile` addressing mode is currently implemented. The functional
+read-modify-write is indivisible in the simulator execution path and therefore
+preserves the PTX element-wise atomic result.
+
+The timing model is not calibrated for `UTMAREDG`. It currently reuses normal
+TMA tensor-store requests and completion. In particular, it does not model the
+atomic destination read, same-address serialization, or a dedicated reduction
+backend resource. Timing results for tensor reduction stores must be treated as
+uncalibrated until a hardware microbenchmark supplies those parameters.
 
 ---
 
@@ -375,6 +402,8 @@ void cycle();
 
 1. **CP.ASYNC sector masking**: Corner cases with non-cacheline-aligned sizes not fully handled
 2. **Tensormap options**: Some tensormap manipulation options not fully validated
+3. **Tensor reduction timing**: Functional semantics are implemented, but the
+   `UTMAREDG` atomic timing path is not calibrated
 
 **Multi-dimensional testing**: Full test coverage for 1D and 3D-5D tensor
 operations is implemented in

--- a/src/gpgpu-sim/flash/tma_reduction.cc
+++ b/src/gpgpu-sim/flash/tma_reduction.cc
@@ -1,0 +1,249 @@
+#include "tma_reduction.h"
+
+#include "tensormap.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <type_traits>
+
+#include "../../cuda-sim/half.h"
+#include "../../cuda-sim/half.hpp"
+
+namespace {
+
+template <typename T> T load_element(const void *buffer, size_t index) {
+  T value;
+  memcpy(&value, static_cast<const uint8_t *>(buffer) + index * sizeof(T),
+         sizeof(T));
+  return value;
+}
+
+template <typename T>
+void store_element(void *buffer, size_t index, const T &value) {
+  memcpy(static_cast<uint8_t *>(buffer) + index * sizeof(T), &value, sizeof(T));
+}
+
+float f16_to_f32(uint16_t value) {
+  return half_float::detail::half2float<float>(value);
+}
+
+uint16_t f32_to_f16(float value) {
+  return half_float::detail::float2half<std::round_to_nearest>(value);
+}
+
+float bf16_to_f32(uint16_t value) {
+  const uint32_t bits = static_cast<uint32_t>(value) << 16;
+  float result;
+  memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+uint16_t f32_to_bf16(float value) {
+  uint32_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  if ((bits & 0x7f800000u) == 0x7f800000u) {
+    return static_cast<uint16_t>((bits >> 16) |
+                                 ((bits & 0xffffu) != 0u ? 1u : 0u));
+  }
+  const uint32_t rounding_bias = 0x7fffu + ((bits >> 16) & 1u);
+  return static_cast<uint16_t>((bits + rounding_bias) >> 16);
+}
+
+template <typename T>
+void reduce_integer(tma_reduction_op_t op, void *dst, const void *src,
+                    size_t count) {
+  using unsigned_t = typename std::make_unsigned<T>::type;
+  for (size_t i = 0; i < count; ++i) {
+    const T dst_value = load_element<T>(dst, i);
+    const T src_value = load_element<T>(src, i);
+    T result{};
+    switch (op) {
+    case tma_reduction_op_t::ADD: {
+      const unsigned_t sum = static_cast<unsigned_t>(dst_value) +
+                             static_cast<unsigned_t>(src_value);
+      memcpy(&result, &sum, sizeof(result));
+      break;
+    }
+    case tma_reduction_op_t::MIN:
+      result = std::min(dst_value, src_value);
+      break;
+    case tma_reduction_op_t::MAX:
+      result = std::max(dst_value, src_value);
+      break;
+    case tma_reduction_op_t::INC:
+      result = dst_value >= src_value ? 0 : dst_value + 1;
+      break;
+    case tma_reduction_op_t::DEC:
+      result =
+          (dst_value == 0 || dst_value > src_value) ? src_value : dst_value - 1;
+      break;
+    case tma_reduction_op_t::BIT_AND:
+      result = static_cast<T>(static_cast<unsigned_t>(dst_value) &
+                              static_cast<unsigned_t>(src_value));
+      break;
+    case tma_reduction_op_t::BIT_OR:
+      result = static_cast<T>(static_cast<unsigned_t>(dst_value) |
+                              static_cast<unsigned_t>(src_value));
+      break;
+    case tma_reduction_op_t::BIT_XOR:
+      result = static_cast<T>(static_cast<unsigned_t>(dst_value) ^
+                              static_cast<unsigned_t>(src_value));
+      break;
+    default:
+      throw std::invalid_argument("invalid integer TMA reduction operation");
+    }
+    store_element(dst, i, result);
+  }
+}
+
+float flush_subnormal(float value) {
+  return std::fpclassify(value) == FP_SUBNORMAL ? std::copysign(0.0f, value)
+                                                : value;
+}
+
+void reduce_f32_add(bool ftz, void *dst, const void *src, size_t count) {
+  for (size_t i = 0; i < count; ++i) {
+    const float raw_dst_value = load_element<float>(dst, i);
+    const float raw_src_value = load_element<float>(src, i);
+    const float dst_value =
+        ftz ? flush_subnormal(raw_dst_value) : raw_dst_value;
+    const float src_value =
+        ftz ? flush_subnormal(raw_src_value) : raw_src_value;
+    const float sum = dst_value + src_value;
+    const float result = ftz ? flush_subnormal(sum) : sum;
+    store_element(dst, i, result);
+  }
+}
+
+void reduce_f16_like(tma_reduction_op_t op, bool bf16, void *dst,
+                     const void *src, size_t count) {
+  for (size_t i = 0; i < count; ++i) {
+    const uint16_t dst_bits = load_element<uint16_t>(dst, i);
+    const uint16_t src_bits = load_element<uint16_t>(src, i);
+    const float dst_value = bf16 ? bf16_to_f32(dst_bits) : f16_to_f32(dst_bits);
+    const float src_value = bf16 ? bf16_to_f32(src_bits) : f16_to_f32(src_bits);
+    float result;
+    switch (op) {
+    case tma_reduction_op_t::ADD:
+      result = dst_value + src_value;
+      break;
+    case tma_reduction_op_t::MIN:
+      result = std::fmin(dst_value, src_value);
+      break;
+    case tma_reduction_op_t::MAX:
+      result = std::fmax(dst_value, src_value);
+      break;
+    default:
+      throw std::invalid_argument("invalid 16-bit TMA reduction operation");
+    }
+    const uint16_t result_bits =
+        bf16 ? f32_to_bf16(result) : f32_to_f16(result);
+    store_element(dst, i, result_bits);
+  }
+}
+
+bool is_bitwise(tma_reduction_op_t op) {
+  return op == tma_reduction_op_t::BIT_AND ||
+         op == tma_reduction_op_t::BIT_OR || op == tma_reduction_op_t::BIT_XOR;
+}
+
+} // namespace
+
+const char *tma_reduction_op_name(tma_reduction_op_t op) {
+  switch (op) {
+  case tma_reduction_op_t::NONE:
+    return "none";
+  case tma_reduction_op_t::ADD:
+    return "add";
+  case tma_reduction_op_t::MIN:
+    return "min";
+  case tma_reduction_op_t::MAX:
+    return "max";
+  case tma_reduction_op_t::INC:
+    return "inc";
+  case tma_reduction_op_t::DEC:
+    return "dec";
+  case tma_reduction_op_t::BIT_AND:
+    return "and";
+  case tma_reduction_op_t::BIT_OR:
+    return "or";
+  case tma_reduction_op_t::BIT_XOR:
+    return "xor";
+  }
+  return "unknown";
+}
+
+bool tma_tensor_reduction_supported(tma_reduction_op_t op,
+                                    uint32_t tensor_data_type) {
+  switch (tensor_data_type) {
+  case TMA_DTYPE_U32:
+    return op == tma_reduction_op_t::ADD || op == tma_reduction_op_t::MIN ||
+           op == tma_reduction_op_t::MAX || op == tma_reduction_op_t::INC ||
+           op == tma_reduction_op_t::DEC || is_bitwise(op);
+  case TMA_DTYPE_S32:
+    return op == tma_reduction_op_t::ADD || op == tma_reduction_op_t::MIN ||
+           op == tma_reduction_op_t::MAX || is_bitwise(op);
+  case TMA_DTYPE_U64:
+    return op == tma_reduction_op_t::ADD || op == tma_reduction_op_t::MIN ||
+           op == tma_reduction_op_t::MAX || is_bitwise(op);
+  case TMA_DTYPE_S64:
+    return op == tma_reduction_op_t::MIN || op == tma_reduction_op_t::MAX ||
+           is_bitwise(op);
+  case TMA_DTYPE_F16:
+  case TMA_DTYPE_BF16:
+    return op == tma_reduction_op_t::ADD || op == tma_reduction_op_t::MIN ||
+           op == tma_reduction_op_t::MAX;
+  case TMA_DTYPE_F32:
+  case TMA_DTYPE_F32_FTZ:
+    return op == tma_reduction_op_t::ADD;
+  default:
+    return false;
+  }
+}
+
+void apply_tma_tensor_reduction(tma_reduction_op_t op,
+                                uint32_t tensor_data_type, void *dst,
+                                const void *src, size_t size_in_bytes) {
+  if (!tma_tensor_reduction_supported(op, tensor_data_type))
+    throw std::invalid_argument("unsupported TMA tensor reduction type");
+
+  const size_t element_size =
+      tensor_data_type == TMA_DTYPE_F16 || tensor_data_type == TMA_DTYPE_BF16
+          ? sizeof(uint16_t)
+          : (tensor_data_type == TMA_DTYPE_U64 ||
+                     tensor_data_type == TMA_DTYPE_S64
+                 ? sizeof(uint64_t)
+                 : sizeof(uint32_t));
+  if (size_in_bytes % element_size != 0)
+    throw std::invalid_argument("partial element in TMA tensor reduction");
+
+  switch (tensor_data_type) {
+  case TMA_DTYPE_U32:
+    reduce_integer<uint32_t>(op, dst, src, size_in_bytes / sizeof(uint32_t));
+    return;
+  case TMA_DTYPE_S32:
+    reduce_integer<int32_t>(op, dst, src, size_in_bytes / sizeof(int32_t));
+    return;
+  case TMA_DTYPE_U64:
+    reduce_integer<uint64_t>(op, dst, src, size_in_bytes / sizeof(uint64_t));
+    return;
+  case TMA_DTYPE_S64:
+    reduce_integer<int64_t>(op, dst, src, size_in_bytes / sizeof(int64_t));
+    return;
+  case TMA_DTYPE_F16:
+    reduce_f16_like(op, false, dst, src, size_in_bytes / sizeof(uint16_t));
+    return;
+  case TMA_DTYPE_BF16:
+    reduce_f16_like(op, true, dst, src, size_in_bytes / sizeof(uint16_t));
+    return;
+  case TMA_DTYPE_F32:
+  case TMA_DTYPE_F32_FTZ:
+    reduce_f32_add(tensor_data_type == TMA_DTYPE_F32_FTZ, dst, src,
+                   size_in_bytes / sizeof(float));
+    return;
+  default:
+    throw std::invalid_argument("unsupported TMA tensor reduction type");
+  }
+}

--- a/src/gpgpu-sim/flash/tma_reduction.h
+++ b/src/gpgpu-sim/flash/tma_reduction.h
@@ -1,0 +1,30 @@
+#ifndef FLASH_GPGPU_SIM_TMA_REDUCTION_H
+#define FLASH_GPGPU_SIM_TMA_REDUCTION_H
+
+#include <cstddef>
+#include <cstdint>
+
+enum class tma_reduction_op_t {
+  NONE,
+  ADD,
+  MIN,
+  MAX,
+  INC,
+  DEC,
+  BIT_AND,
+  BIT_OR,
+  BIT_XOR,
+};
+
+const char *tma_reduction_op_name(tma_reduction_op_t op);
+
+bool tma_tensor_reduction_supported(tma_reduction_op_t op,
+                                    uint32_t tensor_data_type);
+
+// Applies the element-wise tensor reduction in place to dst. The caller must
+// validate the operation/type pair and provide a whole number of elements.
+void apply_tma_tensor_reduction(tma_reduction_op_t op,
+                                uint32_t tensor_data_type, void *dst,
+                                const void *src, size_t size_in_bytes);
+
+#endif

--- a/test/make/sm120.mk
+++ b/test/make/sm120.mk
@@ -16,9 +16,11 @@ INTEGRATION_MMA_OBJ_DIR = $(OBJ_DIR)/integration/mma
 FLASH_OBJ_DIR = $(OBJ_DIR)/flash
 GPGPUSIM_OBJ_DIR = $(OBJ_DIR)/gpgpu-sim
 
-# bulk_group_test exercises this implementation directly.
-FLASH_SOURCES = $(SRC_DIR)/gpgpu-sim/flash/bulk_group.cc
-FLASH_OBJECTS = $(OBJ_DIR)/flash/bulk_group.cu.o
+# Unit tests exercise these implementations directly.
+FLASH_SOURCES = \
+	$(SRC_DIR)/gpgpu-sim/flash/bulk_group.cc \
+	$(SRC_DIR)/gpgpu-sim/flash/tma_reduction.cc
+FLASH_OBJECTS = $(FLASH_SOURCES:$(SRC_DIR)/gpgpu-sim/flash/%.cc=$(OBJ_DIR)/flash/%.cu.o)
 LOCAL_INTERCONNECT_OBJECT = $(OBJ_DIR)/unit/local_interconnect.cc.o
 MSHR_TABLE_OBJECT = $(GPGPUSIM_OBJ_DIR)/mshr-table.cu.o
 

--- a/test/src/integration/tma_tensor_reduce_test.cc
+++ b/test/src/integration/tma_tensor_reduce_test.cc
@@ -1,0 +1,165 @@
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+constexpr uint32_t kColumns = 16;
+constexpr uint32_t kRows = 2;
+constexpr uint32_t kElements = kColumns * kRows;
+
+__global__ void tensor_reduce_add_kernel(const CUtensorMap *tensor_map,
+                                         const float *contribution) {
+  __shared__ __align__(128) float tile[kElements];
+  if (threadIdx.x < kElements) tile[threadIdx.x] = contribution[threadIdx.x];
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    const uint64_t map_address = reinterpret_cast<uint64_t>(tensor_map);
+    const uint32_t shared_address =
+        static_cast<uint32_t>(__cvta_generic_to_shared(tile));
+    asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
+    asm volatile(
+        "cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.tile.bulk_group "
+        "[%0, {%2, %3}], [%1];\n"
+        :
+        : "l"(map_address), "r"(shared_address), "r"(0), "r"(0)
+        : "memory");
+    asm volatile("cp.async.bulk.commit_group;\n" ::: "memory");
+    asm volatile("cp.async.bulk.wait_group 0;\n" ::: "memory");
+  }
+}
+
+TEST(TmaTensorReduceTest, AddsSharedTileToExistingGlobalTensor) {
+  ASSERT_EQ(cuInit(0), CUDA_SUCCESS);
+
+  std::array<float, kElements> initial;
+  std::array<float, kElements> contribution;
+  std::array<float, kElements> result{};
+  for (uint32_t i = 0; i < kElements; ++i) {
+    initial[i] = static_cast<float>(i) + 0.25f;
+    contribution[i] = static_cast<float>(i % 7) - 2.0f;
+  }
+
+  float *device_output = nullptr;
+  float *device_contribution = nullptr;
+  CUtensorMap *device_tensor_map = nullptr;
+  ASSERT_EQ(cudaMalloc(&device_output, sizeof(initial)), cudaSuccess);
+  ASSERT_EQ(cudaMalloc(&device_contribution, sizeof(contribution)),
+            cudaSuccess);
+  ASSERT_EQ(cudaMalloc(&device_tensor_map, sizeof(CUtensorMap)), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(device_output, initial.data(), sizeof(initial),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(device_contribution, contribution.data(),
+                       sizeof(contribution), cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+  CUtensorMap tensor_map{};
+  const uint64_t global_dimensions[2] = {kColumns, kRows};
+  const uint64_t global_strides[1] = {kColumns * sizeof(float)};
+  const uint32_t box_dimensions[2] = {kColumns, kRows};
+  const uint32_t element_strides[2] = {1, 1};
+  ASSERT_EQ(
+      cuTensorMapEncodeTiled(
+          &tensor_map, CU_TENSOR_MAP_DATA_TYPE_FLOAT32, 2, device_output,
+          global_dimensions, global_strides, box_dimensions, element_strides,
+          CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE,
+          CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE),
+      CUDA_SUCCESS);
+  ASSERT_EQ(cudaMemcpy(device_tensor_map, &tensor_map, sizeof(tensor_map),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+  tensor_reduce_add_kernel<<<1, 32>>>(device_tensor_map, device_contribution);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(result.data(), device_output, sizeof(result),
+                       cudaMemcpyDeviceToHost),
+            cudaSuccess);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_FLOAT_EQ(result[i], initial[i] + contribution[i]) << "index " << i;
+
+  EXPECT_EQ(cudaFree(device_tensor_map), cudaSuccess);
+  EXPECT_EQ(cudaFree(device_contribution), cudaSuccess);
+  EXPECT_EQ(cudaFree(device_output), cudaSuccess);
+}
+
+TEST(TmaTensorReduceTest, DistinguishesFloat32AndFloat32FtzTensorMapTypes) {
+  ASSERT_EQ(cuInit(0), CUDA_SUCCESS);
+
+  std::array<uint32_t, kElements> initial_bits{};
+  std::array<uint32_t, kElements> contribution_bits{};
+  std::array<uint32_t, kElements> result_bits{};
+  contribution_bits[0] = 1u;
+
+  float *device_output = nullptr;
+  float *device_contribution = nullptr;
+  CUtensorMap *device_tensor_map = nullptr;
+  ASSERT_EQ(cudaMalloc(&device_output, sizeof(initial_bits)), cudaSuccess);
+  ASSERT_EQ(cudaMalloc(&device_contribution, sizeof(contribution_bits)),
+            cudaSuccess);
+  ASSERT_EQ(cudaMalloc(&device_tensor_map, sizeof(CUtensorMap)), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(device_output, initial_bits.data(), sizeof(initial_bits),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(device_contribution, contribution_bits.data(),
+                       sizeof(contribution_bits), cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+  CUtensorMap tensor_map{};
+  const uint64_t global_dimensions[2] = {kColumns, kRows};
+  const uint64_t global_strides[1] = {kColumns * sizeof(float)};
+  const uint32_t box_dimensions[2] = {kColumns, kRows};
+  const uint32_t element_strides[2] = {1, 1};
+  ASSERT_EQ(
+      cuTensorMapEncodeTiled(
+          &tensor_map, CU_TENSOR_MAP_DATA_TYPE_FLOAT32, 2, device_output,
+          global_dimensions, global_strides, box_dimensions, element_strides,
+          CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE,
+          CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE),
+      CUDA_SUCCESS);
+  ASSERT_EQ(cudaMemcpy(device_tensor_map, &tensor_map, sizeof(tensor_map),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+  tensor_reduce_add_kernel<<<1, 32>>>(device_tensor_map, device_contribution);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(result_bits.data(), device_output, sizeof(result_bits),
+                       cudaMemcpyDeviceToHost),
+            cudaSuccess);
+  EXPECT_EQ(result_bits[0], 1u);
+
+  ASSERT_EQ(cudaMemcpy(device_output, initial_bits.data(), sizeof(initial_bits),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+  ASSERT_EQ(
+      cuTensorMapEncodeTiled(
+          &tensor_map, CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ, 2, device_output,
+          global_dimensions, global_strides, box_dimensions, element_strides,
+          CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE,
+          CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE),
+      CUDA_SUCCESS);
+  ASSERT_EQ(cudaMemcpy(device_tensor_map, &tensor_map, sizeof(tensor_map),
+                       cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+  tensor_reduce_add_kernel<<<1, 32>>>(device_tensor_map, device_contribution);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(result_bits.data(), device_output, sizeof(result_bits),
+                       cudaMemcpyDeviceToHost),
+            cudaSuccess);
+  EXPECT_EQ(result_bits[0], 0u);
+
+  EXPECT_EQ(cudaFree(device_tensor_map), cudaSuccess);
+  EXPECT_EQ(cudaFree(device_contribution), cudaSuccess);
+  EXPECT_EQ(cudaFree(device_output), cudaSuccess);
+}
+
+}  // namespace

--- a/test/src/unit/tma_reduction_test.cc
+++ b/test/src/unit/tma_reduction_test.cc
@@ -1,0 +1,127 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+#include "gpgpu-sim/flash/tensormap.h"
+#include "gpgpu-sim/flash/tma_reduction.h"
+
+namespace {
+
+TEST(TmaTensorReductionTest, ValidatesDocumentedOperationTypePairs) {
+  EXPECT_TRUE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::ADD, TMA_DTYPE_F32));
+  EXPECT_TRUE(tma_tensor_reduction_supported(tma_reduction_op_t::ADD,
+                                             TMA_DTYPE_F32_FTZ));
+  EXPECT_TRUE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::ADD, TMA_DTYPE_F16));
+  EXPECT_TRUE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::ADD, TMA_DTYPE_BF16));
+  EXPECT_TRUE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::MIN, TMA_DTYPE_S64));
+  EXPECT_TRUE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::INC, TMA_DTYPE_U32));
+  EXPECT_TRUE(tma_tensor_reduction_supported(tma_reduction_op_t::BIT_XOR,
+                                             TMA_DTYPE_U64));
+
+  EXPECT_FALSE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::MIN, TMA_DTYPE_F32));
+  EXPECT_FALSE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::ADD, TMA_DTYPE_S64));
+  EXPECT_FALSE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::INC, TMA_DTYPE_S32));
+  EXPECT_FALSE(
+      tma_tensor_reduction_supported(tma_reduction_op_t::ADD, TMA_DTYPE_F64));
+}
+
+TEST(TmaTensorReductionTest, AppliesIntegerOperations) {
+  std::array<uint32_t, 4> dst = {4, 0, std::numeric_limits<uint32_t>::max(),
+                                 0xf0f0u};
+  const std::array<uint32_t, 4> src = {7, 0, 2, 0x0ff0u};
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::ADD, TMA_DTYPE_U32, dst.data(),
+                             src.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<uint32_t, 4>{11, 0, 1, 0x100e0u}));
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::BIT_XOR, TMA_DTYPE_U32,
+                             dst.data(), src.data(), sizeof(dst));
+  EXPECT_EQ(dst[3], 0x10f10u);
+}
+
+TEST(TmaTensorReductionTest, AppliesSignedMinAndMax) {
+  std::array<int32_t, 4> dst = {-9, 12, -3, 8};
+  const std::array<int32_t, 4> src = {-4, 7, -11, 20};
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::MIN, TMA_DTYPE_S32, dst.data(),
+                             src.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<int32_t, 4>{-9, 7, -11, 8}));
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::MAX, TMA_DTYPE_S32, dst.data(),
+                             src.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<int32_t, 4>{-4, 7, -11, 20}));
+}
+
+TEST(TmaTensorReductionTest, AppliesIncAndDec) {
+  std::array<uint32_t, 4> dst = {0, 2, 5, 7};
+  const std::array<uint32_t, 4> limit = {3, 3, 3, 7};
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::INC, TMA_DTYPE_U32, dst.data(),
+                             limit.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<uint32_t, 4>{1, 3, 0, 0}));
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::DEC, TMA_DTYPE_U32, dst.data(),
+                             limit.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<uint32_t, 4>{0, 2, 3, 7}));
+}
+
+TEST(TmaTensorReductionTest, AppliesFloatingPointAdd) {
+  std::array<float, 4> dst = {1.0f, -2.0f, 3.5f, 0.25f};
+  const std::array<float, 4> src = {0.5f, 4.0f, -1.5f, 0.75f};
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::ADD, TMA_DTYPE_F32, dst.data(),
+                             src.data(), sizeof(dst));
+  EXPECT_EQ(dst, (std::array<float, 4>{1.5f, 2.0f, 2.0f, 1.0f}));
+}
+
+TEST(TmaTensorReductionTest, DistinguishesF32AndF32Ftz) {
+  constexpr uint32_t kSmallestSubnormal = 1;
+  std::array<uint32_t, 1> regular_dst = {0};
+  std::array<uint32_t, 1> ftz_dst = {0};
+  const std::array<uint32_t, 1> src = {kSmallestSubnormal};
+
+  apply_tma_tensor_reduction(tma_reduction_op_t::ADD, TMA_DTYPE_F32,
+                             regular_dst.data(), src.data(), sizeof(src));
+  apply_tma_tensor_reduction(tma_reduction_op_t::ADD, TMA_DTYPE_F32_FTZ,
+                             ftz_dst.data(), src.data(), sizeof(src));
+
+  EXPECT_EQ(regular_dst[0], kSmallestSubnormal);
+  EXPECT_EQ(ftz_dst[0], 0u);
+}
+
+TEST(TmaTensorReductionTest, AppliesF16AndBf16Operations) {
+  std::array<uint16_t, 2> f16_dst = {0x3c00u, 0x4000u};  // 1, 2
+  const std::array<uint16_t, 2> f16_src = {0x4000u, 0x3c00u};
+  apply_tma_tensor_reduction(tma_reduction_op_t::ADD, TMA_DTYPE_F16,
+                             f16_dst.data(), f16_src.data(), sizeof(f16_dst));
+  EXPECT_EQ(f16_dst, (std::array<uint16_t, 2>{0x4200u, 0x4200u}));  // 3, 3
+
+  std::array<uint16_t, 2> bf16_dst = {0x3f80u, 0x4040u};        // 1, 3
+  const std::array<uint16_t, 2> bf16_src = {0x4000u, 0x3f00u};  // 2, 0.5
+  apply_tma_tensor_reduction(tma_reduction_op_t::MAX, TMA_DTYPE_BF16,
+                             bf16_dst.data(), bf16_src.data(),
+                             sizeof(bf16_dst));
+  EXPECT_EQ(bf16_dst, (std::array<uint16_t, 2>{0x4000u, 0x4040u}));
+}
+
+TEST(TmaTensorReductionTest, RejectsUnsupportedCombination) {
+  float dst = 1.0f;
+  const float src = 2.0f;
+  EXPECT_THROW(
+      apply_tma_tensor_reduction(tma_reduction_op_t::MIN, TMA_DTYPE_F32, &dst,
+                                 &src, sizeof(dst)),
+      std::invalid_argument);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- add functional support for `cp.reduce.async.bulk.tensor` tile stores
- implement the PTX operation/type matrix for add, min, max, inc, dec, and, or, and xor
- perform reverse-swizzle followed by element-wise read-modify-write
- correct signed, FP64, BF16, FTZ, and TF32 tensor-map data type encodings, including the host encoder
- preserve the hardware-observed distinction between `FLOAT32` and `FLOAT32_FTZ` subnormal handling
- add focused reduction unit tests and CUDA integration tests

## Timing status

This PR adds functional semantics only. Tensor reduction stores currently reuse the normal TMA tensor-store request and completion path. The timing model does not yet account for the destination atomic read, same-address serialization, or a dedicated reduction backend resource, so `UTMAREDG` timing remains uncalibrated.

## Validation

- full FlashGPU-Sim build with CUDA 12.8
- all 49 SM120 unit tests
- native RTX 5090 integration tests on GPU 1, including `FLOAT32` versus `FLOAT32_FTZ` subnormal behavior
- detailed-simulator integration tests
- native SASS verified as `UTMAREDG.2D.ADD`