### PR TITLE
fix: route TMA instructions through dedicated pipeline

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -499,6 +499,10 @@ void shader_core_ctx::create_exec_pipeline() {
       in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
       out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
     }
+    if (m_config->gpgpu_num_tma_units > 0) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_TMA]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_TMA]);
+    }
     if (m_config->gpgpu_num_cp_async_units > 0) {
       in_ports.push_back(&m_pipeline_reg[ID_OC_CP_ASYNC]);
       out_ports.push_back(&m_pipeline_reg[OC_EX_CP_ASYNC]);
@@ -2480,7 +2484,9 @@ void scheduler_unit::cycle() {
               }
             } else {
               // This code need to be refactored
-              if (pI->op != TENSOR_CORE_OP && pI->op != SFU_OP &&
+              if (pI->op != TENSOR_CORE_OP &&
+                  pI->op != TENSOR_MEMORY_ACCELERATOR_OP &&
+                  pI->op != SFU_OP &&
                   pI->op != DP_OP &&
                   pI->op != ASYNC_COPY_OP &&
                   !(pI->op == TENSOR_MAP_OP &&


### PR DESCRIPTION
Summary
- Exclude TENSOR_MEMORY_ACCELERATOR_OP from the generic SP/INT scheduler path so TMA instructions reach the dedicated TMA issue branch.
- Connect ID_OC_TMA to OC_EX_TMA in the generic operand collector.

Root cause
The generic scheduler branch accepted TMA instructions before the dedicated TMA branch. Asymmetric TMA timing could therefore index the unrelated INT pipeline. Excluding TMA exposed a second missing connection in the generic operand collector, which otherwise left TMA instructions stalled before execution.

Validation
- git diff --check
- source setup_environment && make -j16 gpgpu-sim_uarch
- Additional exact FA4 diagnostics with TMA latency/initiation 32/32, 32/1, and 1/1 all completed main+combine numerical checks and produced identical work trajectories after this fix.

Build note
The top-level make -j16 reaches and builds the modified simulator library, then fails in the unchanged legacy cuobjdump_to_ptxplus PTX parser on undeclared parser helper symbols. The focused gpgpu-sim_uarch target passes.