### PR TITLE
sim: preserve warp ID in functional execution

### DIFF
--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -1065,6 +1065,7 @@ warp_inst_t core_t::getExecuteWarp(unsigned warpId) {
   unsigned pc, rpc;
   m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
   warp_inst_t wi = *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
+  wi.set_warp_id_func(warpId);
   wi.set_active(m_simt_stack[warpId]->get_active_mask());
   return wi;
 }

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1198,6 +1198,7 @@ class warp_inst_t : public inst_t {
   {
     return m_warp_id;
   }
+  void set_warp_id_func(unsigned warp_id) { m_warp_id = warp_id; }
   unsigned dynamic_warp_id() const {
     assert(!m_empty);
     return m_dynamic_warp_id;


### PR DESCRIPTION
## Summary

- Preserve the executing warp ID when pure functional simulation copies a static PTX instruction.
- Prevent warp-collective semantic handlers from resolving every functional warp as warp 0.
- Leave the timing/performance issue path unchanged.

## Root cause

Pure functional simulation obtains a static instruction copy through `core_t::getExecuteWarp()`. Unlike timing simulation, this path does not call `warp_inst_t::issue()`, so the copied instruction retained the default warp ID of 0.

Ordinary per-thread instructions receive the executing warp ID separately. Warp-collective helpers such as WGMMA instead consult `warp_id_func()` to locate their participant threads. A four-warp WGMMA therefore executed each per-warp invocation on warp 0 and never updated warps 1-3.

The fix adds a functional-only setter and records `warpId` on the copied instruction before execution.

## Validation

- `make FLASH=1 -j8` with CUDA 13.3: passed.
- Nonzero BF16 WGMMA functional regression linked against the freshly built simulator: 2/2 passed (`scale_d=1` and `scale_d=0`).
- `git diff --check origin/flash...HEAD`: passed.

The repository WGMMA wrapper currently fails to assemble under the local CUDA 13.3 toolchain because `nvcc -arch=sm_90a` emits a `.target sm_90` PTX file that `ptxas` rejects for WGMMA. The numerical regression above used the same WGMMA gtest built explicitly for `compute_90a`; it loaded this branch fresh simulator library.