### PR TITLE
sim: support PTX .v8 memory operands

### DIFF
--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -2759,6 +2759,16 @@ using flash_gpgpu_sim::wgmma_wait_group_impl;
         if (pI->m_is_ldgsts) {
           inst.set_per_thread_memory_access_size(
               lane_id, last_memory_access_size());
+        } else if (pI->get_vector() != 0 &&
+                   (pI->has_memory_read() || pI->has_memory_write())) {
+          unsigned vector_width = 0;
+          if (pI->get_vector() == V2_TYPE) vector_width = 2;
+          if (pI->get_vector() == V3_TYPE) vector_width = 3;
+          if (pI->get_vector() == V4_TYPE) vector_width = 4;
+          if (pI->get_vector() == V8_TYPE) vector_width = 8;
+          assert(vector_width != 0);
+          inst.set_per_thread_memory_access_size(lane_id,
+                                                 insn_data_size * vector_width);
         }
         inst.data_size = insn_data_size;  // simpleAtomicIntrinsics
         assert(inst.memory_op == insn_memory_op);

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -853,44 +853,33 @@ void ptx_thread_info::set_operand_value(const operand_info &dst,
 }
 
 void ptx_thread_info::set_vector_operand_values(const operand_info &dst,
+                                                const ptx_reg_t *values,
+                                                unsigned num_elements) {
+  assert(dst.is_vector());
+  assert(num_elements == dst.get_vect_nelem());
+  assert(num_elements > 0 && num_elements <= 8);
+  for (unsigned i = 0; i < num_elements; ++i) {
+    set_reg(dst.vec_symbol(i), values[i]);
+  }
+  m_last_set_operand_value = values[0];
+}
+
+void ptx_thread_info::set_vector_operand_values(const operand_info &dst,
                                                 const ptx_reg_t &data1,
                                                 const ptx_reg_t &data2,
                                                 const ptx_reg_t &data3,
                                                 const ptx_reg_t &data4) {
-  unsigned num_elements = dst.get_vect_nelem();
-  if (num_elements > 0) {
-    set_reg(dst.vec_symbol(0), data1);
-    if (num_elements > 1) {
-      set_reg(dst.vec_symbol(1), data2);
-      if (num_elements > 2) {
-        set_reg(dst.vec_symbol(2), data3);
-        if (num_elements > 3) {
-          set_reg(dst.vec_symbol(3), data4);
-        }
-      }
-    }
-  }
-
-  m_last_set_operand_value = data1;
+  assert(dst.get_vect_nelem() <= 4);
+  const ptx_reg_t values[] = {data1, data2, data3, data4};
+  set_vector_operand_values(dst, values, dst.get_vect_nelem());
 }
 void ptx_thread_info::set_wmma_vector_operand_values(
     const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
     const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
     const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8) {
-  unsigned num_elements = dst.get_vect_nelem();
-  if (num_elements == 8) {
-    set_reg(dst.vec_symbol(0), data1);
-    set_reg(dst.vec_symbol(1), data2);
-    set_reg(dst.vec_symbol(2), data3);
-    set_reg(dst.vec_symbol(3), data4);
-    set_reg(dst.vec_symbol(4), data5);
-    set_reg(dst.vec_symbol(5), data6);
-    set_reg(dst.vec_symbol(6), data7);
-    set_reg(dst.vec_symbol(7), data8);
-  } else {
-    printf("error:set_wmma_vector_operands");
-  }
-
+  const ptx_reg_t values[] = {data1, data2, data3, data4,
+                              data5, data6, data7, data8};
+  set_vector_operand_values(dst, values, 8);
   m_last_set_operand_value = data8;
 }
 
@@ -3716,18 +3705,19 @@ void ld_exec(const ptx_instruction *pI, ptx_thread_info *thread) {
     }
 
   } else {
-    ptx_reg_t data1, data2, data3, data4;
-    mem->read(addr, size / 8, &data1.s64);
-    mem->read(addr + size / 8, size / 8, &data2.s64);
-    if (vector_spec != V2_TYPE) {  // either V3 or V4
-      mem->read(addr + 2 * size / 8, size / 8, &data3.s64);
-      if (vector_spec != V3_TYPE) {  // v4
-        mem->read(addr + 3 * size / 8, size / 8, &data4.s64);
-        thread->set_vector_operand_values(dst, data1, data2, data3, data4);
-      } else  // v3
-        thread->set_vector_operand_values(dst, data1, data2, data3, data3);
-    } else  // v2
-      thread->set_vector_operand_values(dst, data1, data2, data2, data2);
+    unsigned vector_width = 0;
+    if (vector_spec == V2_TYPE) vector_width = 2;
+    if (vector_spec == V3_TYPE) vector_width = 3;
+    if (vector_spec == V4_TYPE) vector_width = 4;
+    if (vector_spec == V8_TYPE) vector_width = 8;
+    assert(vector_width == dst.get_vect_nelem());
+
+    ptx_reg_t values[8] = {};
+    const size_t element_bytes = size / 8;
+    for (unsigned i = 0; i < vector_width; ++i) {
+      mem->read(addr + i * element_bytes, element_bytes, &values[i].s64);
+    }
+    thread->set_vector_operand_values(dst, values, vector_width);
   }
   thread->m_last_effective_address = addr;
   thread->m_last_memory_space = space;
@@ -6270,37 +6260,19 @@ void st_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
     }
 
   } else {
-    if (vector_spec == V2_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[2];
-      thread->get_vector_operand_values(src1, ptx_regs, 2);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      delete[] ptx_regs;
-    }
-    if (vector_spec == V3_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[3];
-      thread->get_vector_operand_values(src1, ptx_regs, 3);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
-      delete[] ptx_regs;
-    }
-    if (vector_spec == V4_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[4];
-      thread->get_vector_operand_values(src1, ptx_regs, 4);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
-      mem->write(addr + 3 * size / 8, size / 8, &ptx_regs[3].s64, thread, pI);
+    unsigned vector_width = 0;
+    if (vector_spec == V2_TYPE) vector_width = 2;
+    if (vector_spec == V3_TYPE) vector_width = 3;
+    if (vector_spec == V4_TYPE) vector_width = 4;
+    if (vector_spec == V8_TYPE) vector_width = 8;
+    assert(vector_width == src1.get_vect_nelem());
 
-      GPPRINTF_INST_EXEC(PTX_INST_EXEC,
-                        "st.v4: space %p type %s addr %llx data %llu %llu %llu "
-                        "%llu inst %s\n",
-                        mem, decode_token(type), addr, ptx_regs[0].u64,
-                        ptx_regs[1].u64, ptx_regs[2].u64, ptx_regs[3].u64,
-                        pI->to_string().c_str());
-
-      delete[] ptx_regs;
+    ptx_reg_t values[8] = {};
+    thread->get_vector_operand_values(src1, values, vector_width);
+    const size_t element_bytes = size / 8;
+    for (unsigned i = 0; i < vector_width; ++i) {
+      mem->write(addr + i * element_bytes, element_bytes, &values[i].s64,
+                 thread, pI);
     }
   }
   thread->m_last_effective_address = addr;

--- a/src/cuda-sim/ptx.l
+++ b/src/cuda-sim/ptx.l
@@ -378,6 +378,7 @@ breakaddr  TC; yylval->int_value = BREAKADDR_OP; return OPCODE;
 \.v2	TC; return V2_TYPE;
 \.v3	TC; return V3_TYPE;
 \.v4	TC; return V4_TYPE;
+\.v8	TC; return V8_TYPE;
 
 \.half  TC; return HALF_OPTION; /* ptxplus */
 \.cc	TC; return EXTP_OPTION; /* extended precision option */

--- a/src/cuda-sim/ptx.y
+++ b/src/cuda-sim/ptx.y
@@ -125,6 +125,7 @@ class ptx_recognizer;
 %token  V2_TYPE
 %token  V3_TYPE
 %token  V4_TYPE
+%token  V8_TYPE
 %token  COMMA
 %token  PRED
 %token  HALF_OPTION
@@ -481,6 +482,7 @@ type_spec: scalar_type
 vector_spec:  V2_TYPE {  recognizer->add_option(V2_TYPE); recognizer->func_header_info(".v2");}
 	| V3_TYPE     {  recognizer->add_option(V3_TYPE); recognizer->func_header_info(".v3");}
 	| V4_TYPE     {  recognizer->add_option(V4_TYPE); recognizer->func_header_info(".v4");}
+	| V8_TYPE     {  recognizer->add_option(V8_TYPE); recognizer->func_header_info(".v8");}
 	;
 
 scalar_type: S8_TYPE { recognizer->add_scalar_type_spec( S8_TYPE ); }

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -1552,6 +1552,7 @@ ptx_instruction::ptx_instruction(
       case V2_TYPE:
       case V3_TYPE:
       case V4_TYPE:
+      case V8_TYPE:
         m_vector_spec = last_ptx_inst_option;
         break;
       case ATOMIC_AND:

--- a/src/cuda-sim/ptx_sim.h
+++ b/src/cuda-sim/ptx_sim.h
@@ -440,6 +440,9 @@ class ptx_thread_info {
   void get_vector_operand_values(const operand_info &op, ptx_reg_t *ptx_regs,
                                  unsigned num_elements);
   void set_vector_operand_values(const operand_info &dst,
+                                 const ptx_reg_t *values,
+                                 unsigned num_elements);
+  void set_vector_operand_values(const operand_info &dst,
                                  const ptx_reg_t &data1, const ptx_reg_t &data2,
                                  const ptx_reg_t &data3,
                                  const ptx_reg_t &data4);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,7 @@ $(BUILD_DIR) $(OBJ_DIR) $(BIN_DIR) $(SM90_OBJ_DIR):
 # Workload fragments declare custom groups and runner metadata before the
 # generic GoogleTest build graph is registered.
 include make/gtest.mk
+include make/workloads/blackwell.mk
 include make/workloads/fa.mk
 include make/workloads/fa2.mk
 include make/workloads/fa3.mk

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,6 +98,7 @@ src/
 ├── include/       shared test-only headers (not a test group)
 ├── unit/          host-side simulator component tests
 ├── integration/   cross-architecture standalone CUDA tests
+├── blackwell/     SM100+ instruction integration tests
 ├── barrier/       named barrier and mbarrier tests
 ├── tma/           TMA and tensor-map tests
 ├── mma/           mma.sync tests

--- a/tests/arch/sm120.toml
+++ b/tests/arch/sm120.toml
@@ -18,6 +18,9 @@ sources = [
   "integration/ldst_matrix_test.cu",
   "integration/cp_async_src_size_test.cu",
 
+  # Blackwell vector-memory forms emitted by native kernels.
+  "blackwell/vector_ldst_v8_test.cu",
+
   # SM120 correctness groups.
   "barrier/mbarrier_test.cu",
   "barrier/mbarrier_sanity_test.cu",

--- a/tests/ci/jobs.toml
+++ b/tests/ci/jobs.toml
@@ -6,6 +6,7 @@ arch = "sm120"
 tests = [
   { name = "unit", group = "unit" },
   { name = "integration", group = "integration" },
+  { name = "blackwell", group = "blackwell", gtest_filter = "BlackwellVectorLdstIntegrationTest.*", post_check = "tests/scripts/check_vector_v8_transactions.py" },
   { name = "barrier", group = "barrier", gtest_filter = "*-MBarrierSanityTest.*" },
   { name = "tma", group = "tma", gtest_filter = "*-*CPAsyncMethod*:*PerformanceComparison*" },
   { name = "mma", group = "mma" },

--- a/tests/make/workloads/blackwell.mk
+++ b/tests/make/workloads/blackwell.mk
@@ -1,0 +1,52 @@
+# Blackwell PTX-ISA regression tests.
+
+BLACKWELL_MK := $(lastword $(MAKEFILE_LIST))
+WORKLOAD_MANAGED_TEST_GROUPS_sm120 += blackwell
+
+TEST_GROUP_BUILD_TARGET_sm120_blackwell := build-sm120-blackwell
+TEST_GROUP_BINARY_GROUP_sm120_blackwell := sm120-blackwell
+TEST_GROUP_EXECUTOR_sm120_blackwell := gtest-single
+TEST_GROUP_FILTER_sm120_blackwell := *
+
+BLACKWELL_SM120_OBJECTS := $(patsubst $(TEST_SRC_DIR)/%.cu,\
+	$(OBJ_DIR)/sm120/%.cu.o,$(TEST_GROUP_SOURCES_sm120_blackwell))
+BLACKWELL_SM120_BINARY := $(BIN_DIR)/sm120/blackwell_tests.bin
+BLACKWELL_SM120_LAUNCHER := $(BIN_DIR)/sm120/blackwell_tests
+BLACKWELL_SM120_LAUNCHER_SOURCE := \
+	$(TEST_SRC_DIR)/blackwell/run_vector_ldst_v8_test.sh
+BLACKWELL_SM120_PTX_SOURCE := $(TEST_SRC_DIR)/blackwell/vector_ldst_v8_test.ptx
+BLACKWELL_SM120_PTX := $(BIN_DIR)/sm120/vector_ldst_v8_test.ptx
+BLACKWELL_SM120_PTXINFO_SOURCE := \
+	$(TEST_SRC_DIR)/blackwell/vector_ldst_v8_test.ptxinfo
+BLACKWELL_SM120_PTXINFO := $(BIN_DIR)/sm120/vector_ldst_v8_test.ptxinfo
+
+BINARY_GROUPS += sm120-blackwell
+BINARY_GROUP_BINARIES_sm120-blackwell := $(BLACKWELL_SM120_LAUNCHER)
+
+$(BLACKWELL_SM120_OBJECTS): NVCC_COMPILE_FLAGS = $(BASE_NVCCFLAGS) \
+	-arch=$(ARCH_NVCC_TARGET_sm120)
+
+.PHONY: build-sm120-blackwell
+build-sm120-blackwell: setup-gtest $(BLACKWELL_SM120_LAUNCHER)
+
+$(BLACKWELL_SM120_BINARY): $(BLACKWELL_SM120_OBJECTS) \
+$(OBJ_DIR)/gtest_main.a $(TOP_MAKEFILE) $(BLACKWELL_MK) arch/sm120.toml \
+$(ARCH_MANIFEST_SCRIPT)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(BLACKWELL_SM120_OBJECTS) $(OBJ_DIR)/gtest_main.a \
+		-o $@ -lpthread $(CUDA_LIBS)
+
+$(BLACKWELL_SM120_PTX): $(BLACKWELL_SM120_PTX_SOURCE) $(BLACKWELL_MK)
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+$(BLACKWELL_SM120_PTXINFO): $(BLACKWELL_SM120_PTXINFO_SOURCE) $(BLACKWELL_MK)
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+$(BLACKWELL_SM120_LAUNCHER): $(BLACKWELL_SM120_BINARY) \
+$(BLACKWELL_SM120_PTX) $(BLACKWELL_SM120_PTXINFO) \
+$(BLACKWELL_SM120_LAUNCHER_SOURCE) $(BLACKWELL_MK)
+	@mkdir -p $(dir $@)
+	cp $(BLACKWELL_SM120_LAUNCHER_SOURCE) $@
+	chmod +x $@

--- a/tests/scripts/check_vector_v8_transactions.py
+++ b/tests/scripts/check_vector_v8_transactions.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Check coalesced traffic for the SM120 vector load/store test."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+EXPECTED = {
+    "GLOBAL_ACC_R": 5,
+    "GLOBAL_ACC_W": 32,
+}
+
+COUNTER_RE = re.compile(
+    r"Total_core_cache_stats_breakdown\[(GLOBAL_ACC_[RW])\]"
+    r"\[TOTAL_ACCESS\] = ([0-9]+)"
+)
+
+
+def validate(log_path: Path) -> None:
+    actual: dict[str, int] = {}
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = COUNTER_RE.search(line)
+        if match:
+            actual[match.group(1)] = int(match.group(2))
+
+    if actual != EXPECTED:
+        raise ValueError(f"expected {EXPECTED}, got {actual}")
+
+    print("Validated .v8 load/store coalescing traffic")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} LOG", file=sys.stderr)
+        return 2
+
+    try:
+        validate(Path(sys.argv[1]))
+    except (OSError, ValueError) as error:
+        print(f".v8 traffic validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/src/blackwell/run_vector_ldst_v8_test.sh
+++ b/tests/src/blackwell/run_vector_ldst_v8_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+launcher_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PTX_SIM_USE_PTX_FILE=1
+export PTX_SIM_KERNELFILE="$launcher_dir/vector_ldst_v8_test.ptx"
+export GPGPUSIM_SELECTED_PTX_OVERRIDE="$PTX_SIM_KERNELFILE"
+
+exec "$launcher_dir/blackwell_tests.bin" "$@"

--- a/tests/src/blackwell/vector_ldst_v8_test.cu
+++ b/tests/src/blackwell/vector_ldst_v8_test.cu
@@ -1,0 +1,83 @@
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+struct Words8 {
+  uint32_t value[8];
+};
+
+__device__ __forceinline__ Words8 load_global_v8(const uint32_t *address) {
+  Words8 words;
+  asm volatile("ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+               : "=r"(words.value[0]), "=r"(words.value[1]),
+                 "=r"(words.value[2]), "=r"(words.value[3]),
+                 "=r"(words.value[4]), "=r"(words.value[5]),
+                 "=r"(words.value[6]), "=r"(words.value[7])
+               : "l"(reinterpret_cast<uint64_t>(address)));
+  return words;
+}
+
+__device__ __forceinline__ void store_global_v8(uint32_t *address,
+                                                const Words8 &words) {
+  asm volatile("st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+               :
+               : "l"(reinterpret_cast<uint64_t>(address)), "r"(words.value[0]),
+                 "r"(words.value[1]), "r"(words.value[2]), "r"(words.value[3]),
+                 "r"(words.value[4]), "r"(words.value[5]), "r"(words.value[6]),
+                 "r"(words.value[7])
+               : "memory");
+}
+
+__global__ void vector_ldst_v8_kernel(const uint32_t *input, uint32_t *output) {
+  const unsigned lane = threadIdx.x;
+  Words8 words = load_global_v8(input + lane);
+#pragma unroll
+  for (unsigned i = 0; i < 8; ++i) words.value[i] ^= 0xa5a50000U + 17U * i;
+  store_global_v8(output + 8 * lane, words);
+}
+
+TEST(BlackwellVectorLdstIntegrationTest,
+     GlobalV8B32MovesAllEightWordsPerThread) {
+  constexpr unsigned kThreads = 32;
+  constexpr unsigned kInputWords = kThreads + 7;
+  constexpr unsigned kOutputWords = 8 * kThreads;
+  std::vector<uint32_t> input(kInputWords);
+  std::vector<uint32_t> output(kOutputWords, 0);
+  for (unsigned i = 0; i < kInputWords; ++i) input[i] = 0x10203040U + 31U * i;
+
+  uint32_t *device_input = nullptr;
+  uint32_t *device_output = nullptr;
+  ASSERT_EQ(cudaMalloc(&device_input, kInputWords * sizeof(uint32_t)),
+            cudaSuccess);
+  ASSERT_EQ(cudaMalloc(&device_output, kOutputWords * sizeof(uint32_t)),
+            cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(device_input, input.data(),
+                       kInputWords * sizeof(uint32_t), cudaMemcpyHostToDevice),
+            cudaSuccess);
+  ASSERT_EQ(cudaMemset(device_output, 0, kOutputWords * sizeof(uint32_t)),
+            cudaSuccess);
+
+  vector_ldst_v8_kernel<<<1, kThreads>>>(device_input, device_output);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(cudaMemcpy(output.data(), device_output,
+                       kOutputWords * sizeof(uint32_t), cudaMemcpyDeviceToHost),
+            cudaSuccess);
+
+  for (unsigned lane = 0; lane < kThreads; ++lane) {
+    for (unsigned i = 0; i < 8; ++i) {
+      const unsigned index = 8 * lane + i;
+      EXPECT_EQ(output[index], input[lane + i] ^ (0xa5a50000U + 17U * i))
+          << "lane " << lane << ", element " << i;
+    }
+  }
+
+  EXPECT_EQ(cudaFree(device_output), cudaSuccess);
+  EXPECT_EQ(cudaFree(device_input), cudaSuccess);
+}
+
+}  // namespace

--- a/tests/src/blackwell/vector_ldst_v8_test.cu
+++ b/tests/src/blackwell/vector_ldst_v8_test.cu
@@ -4,41 +4,17 @@
 #include <cstdint>
 #include <vector>
 
-namespace {
-
-struct Words8 {
-  uint32_t value[8];
-};
-
-__device__ __forceinline__ Words8 load_global_v8(const uint32_t *address) {
-  Words8 words;
-  asm volatile("ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
-               : "=r"(words.value[0]), "=r"(words.value[1]),
-                 "=r"(words.value[2]), "=r"(words.value[3]),
-                 "=r"(words.value[4]), "=r"(words.value[5]),
-                 "=r"(words.value[6]), "=r"(words.value[7])
-               : "l"(reinterpret_cast<uint64_t>(address)));
-  return words;
-}
-
-__device__ __forceinline__ void store_global_v8(uint32_t *address,
-                                                const Words8 &words) {
-  asm volatile("st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
-               :
-               : "l"(reinterpret_cast<uint64_t>(address)), "r"(words.value[0]),
-                 "r"(words.value[1]), "r"(words.value[2]), "r"(words.value[3]),
-                 "r"(words.value[4]), "r"(words.value[5]), "r"(words.value[6]),
-                 "r"(words.value[7])
-               : "memory");
-}
-
-__global__ void vector_ldst_v8_kernel(const uint32_t *input, uint32_t *output) {
+// CUDA 12.8 only supports PTX ISA 8.7, while .v8.b32 memory operands were
+// added in PTX ISA 8.8. The test launcher replaces this placeholder with the
+// adjacent handwritten PTX fixture so CI can exercise the simulator without
+// requiring a newer ptxas. Keep the signature synchronized with that fixture.
+extern "C" __global__ void vector_ldst_v8_kernel(const uint32_t *input,
+                                                  uint32_t *output) {
   const unsigned lane = threadIdx.x;
-  Words8 words = load_global_v8(input + lane);
-#pragma unroll
-  for (unsigned i = 0; i < 8; ++i) words.value[i] ^= 0xa5a50000U + 17U * i;
-  store_global_v8(output + 8 * lane, words);
+  output[lane] = input[lane];
 }
+
+namespace {
 
 TEST(BlackwellVectorLdstIntegrationTest,
      GlobalV8B32MovesAllEightWordsPerThread) {

--- a/tests/src/blackwell/vector_ldst_v8_test.ptx
+++ b/tests/src/blackwell/vector_ldst_v8_test.ptx
@@ -1,0 +1,36 @@
+.version 8.8
+.target sm_120a
+.address_size 64
+
+.visible .entry vector_ldst_v8_kernel(
+    .param .u64 .ptr .align 1 vector_ldst_v8_kernel_param_0,
+    .param .u64 .ptr .align 1 vector_ldst_v8_kernel_param_1
+)
+{
+    .reg .b32 %r<19>;
+    .reg .b64 %rd<7>;
+
+    ld.param.b64 %rd3, [vector_ldst_v8_kernel_param_0];
+    ld.param.b64 %rd4, [vector_ldst_v8_kernel_param_1];
+    mov.u32 %r17, %tid.x;
+    mul.wide.u32 %rd5, %r17, 4;
+    add.s64 %rd1, %rd3, %rd5;
+
+    ld.global.v8.b32 {%r1, %r2, %r3, %r4, %r5, %r6, %r7, %r8}, [%rd1];
+
+    xor.b32 %r9, %r1, -1515913216;
+    xor.b32 %r10, %r2, -1515913199;
+    xor.b32 %r11, %r3, -1515913182;
+    xor.b32 %r12, %r4, -1515913165;
+    xor.b32 %r13, %r5, -1515913148;
+    xor.b32 %r14, %r6, -1515913131;
+    xor.b32 %r15, %r7, -1515913114;
+    xor.b32 %r16, %r8, -1515913097;
+    shl.b32 %r18, %r17, 3;
+    mul.wide.u32 %rd6, %r18, 4;
+    add.s64 %rd2, %rd4, %rd6;
+
+    st.global.v8.b32 [%rd2], {%r9, %r10, %r11, %r12, %r13, %r14, %r15, %r16};
+
+    ret;
+}

--- a/tests/src/blackwell/vector_ldst_v8_test.ptxinfo
+++ b/tests/src/blackwell/vector_ldst_v8_test.ptxinfo
@@ -1,0 +1,5 @@
+ptxas info    : 0 bytes gmem
+ptxas info    : Compiling entry function 'vector_ldst_v8_kernel' for 'sm_120a'
+ptxas info    : Function properties for vector_ldst_v8_kernel
+    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
+ptxas info    : Used 10 registers, used 0 barriers


### PR DESCRIPTION
## Summary

- parse and retain the PTX `.v8` vector specifier used by SM100+ 256-bit global loads and stores
- execute all eight registers in functional load/store simulation
- account for the full 32-byte per-thread vector width during memory coalescing
- add an SM120 correctness regression plus a traffic post-check

## Regression

Before the fix, the new test fails on `origin/flash` with a syntax error at `ld.global.v8.b32` and the simulator aborts. After the fix, all eight words per lane match and coalescing reports the expected 5 global-read sectors and 32 global-write sectors.

## Testing

- `python3 tests/scripts/arch_manifests_to_make.py validate`
- `make FLASH=1 -j4` with CUDA 13.3
- `./tests/run_tests.py run --arch sm120 --group blackwell BlackwellVectorLdstIntegrationTest`
- `python3 tests/scripts/check_vector_v8_transactions.py /tmp/flashgpu-v8-green.log`