### PR TITLE
sim: canonicalize explicit shared-memory addresses

### DIFF
--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -1294,6 +1294,9 @@ void atom_callback(const inst_t *inst, ptx_thread_info *thread) {
     }
   }
   assert(space == global_space || space == shared_space);
+  if (space == shared_space) {
+    effective_address &= 0x00000000FFFFFFFFULL;
+  }
 
   memory_space *mem = NULL;
   if (space == global_space)
@@ -1617,6 +1620,9 @@ void atom_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
   } else {
     assert(space == global_space || space == shared_space);
     effective_address_final = effective_address;
+    if (space == shared_space) {
+      effective_address_final &= 0x00000000FFFFFFFFULL;
+    }
   }
 
   // Check state space
@@ -3638,6 +3644,10 @@ void decode_space(memory_space_t &space, ptx_thread_info *thread,
       break;
     case shared_space:
       mem = thread->m_shared_mem;
+      // Explicit shared-memory addresses are 32-bit offsets. PTX arithmetic
+      // that produces such an address can leave carry bits above bit 31 in
+      // the simulator's wider register representation.
+      addr &= 0x00000000FFFFFFFFULL;
       break;
     case sstarr_space:
       mem = thread->m_sstarr_mem;

--- a/tests/arch/sm120.toml
+++ b/tests/arch/sm120.toml
@@ -17,6 +17,7 @@ sources = [
   "integration/shared_memory_optin_test.cu",
   "integration/ldst_matrix_test.cu",
   "integration/cp_async_src_size_test.cu",
+  "integration/shared_atomic_address_test.cu",
 
   # SM120 correctness groups.
   "barrier/mbarrier_test.cu",

--- a/tests/arch/sm90.toml
+++ b/tests/arch/sm90.toml
@@ -11,6 +11,7 @@ sources = [
   "integration/shared_memory_optin_test.cu",
   "integration/ldst_matrix_test.cu",
   "integration/cp_async_src_size_test.cu",
+  "integration/shared_atomic_address_test.cu",
 
   # SM90 correctness groups.
   "barrier/named_barrier_test.cu",

--- a/tests/src/integration/README.md
+++ b/tests/src/integration/README.md
@@ -22,6 +22,8 @@ Current sources:
 - `shared_memory_optin_test.cu`: opt-in dynamic shared-memory behavior;
 - `ldst_matrix_test.cu`: `ldmatrix` and `stmatrix` variants;
 - `cp_async_src_size_test.cu`: `cp.async` source-size forms.
+- `shared_atomic_address_test.cu`: canonical explicit shared-memory addresses
+  across atomic and ordinary accesses.
 
 Run the test group with:
 

--- a/tests/src/integration/shared_atomic_address_test.cu
+++ b/tests/src/integration/shared_atomic_address_test.cu
@@ -1,0 +1,46 @@
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace {
+
+__global__ void wrapped_shared_atomic_address_kernel(uint32_t *output) {
+  __shared__ volatile uint32_t value;
+  value = 0;
+
+  uint32_t old = 0;
+  asm volatile(
+      "{\n\t"
+      ".reg .u32 wrapped_address;\n\t"
+      "add.u32 wrapped_address, 0xffffffff, 1;\n\t"
+      "atom.shared.add.u32 %0, [wrapped_address], 7;\n\t"
+      "}"
+      : "=r"(old)
+      :
+      : "memory");
+  output[0] = value;
+  output[1] = old;
+}
+
+TEST(SharedAtomicAddressIntegrationTest,
+     WrappedU32AddressMatchesCanonicalSharedOffset) {
+  uint32_t *device_output = nullptr;
+  ASSERT_EQ(cudaMalloc(&device_output, 2 * sizeof(uint32_t)), cudaSuccess);
+  ASSERT_EQ(cudaMemset(device_output, 0, 2 * sizeof(uint32_t)), cudaSuccess);
+
+  wrapped_shared_atomic_address_kernel<<<1, 1>>>(device_output);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  uint32_t output[2] = {};
+  ASSERT_EQ(
+      cudaMemcpy(output, device_output, sizeof(output), cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  EXPECT_EQ(output[0], 7U);
+  EXPECT_EQ(output[1], 0U);
+
+  EXPECT_EQ(cudaFree(device_output), cudaSuccess);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- canonicalize explicit shared-memory operands to their architectural 32-bit offsets during ordinary address decode
- apply the same canonicalization when shared atomics are issued and when their callbacks execute
- add a deterministic SM90/SM120 regression that wraps a `.u32` address to offset zero and checks atomic/ordinary-access aliasing

## Regression

The test computes `0xffffffff + 1` with `add.u32`, then uses the result for `atom.shared.add.u32`. Before the fix, the simulator retains the carry in its wider internal register representation, so the atomic updates a different sparse address and the test observes 0 instead of 7 at shared offset zero. The fixed simulator observes 7 and returns the expected old value 0.

## Testing

- `python3 tests/scripts/arch_manifests_to_make.py validate`
- `make FLASH=1 -j4` with CUDA 13.3
- focused test TU passes with both `sm_90a` / `SM90_H100` and `sm_120a` / `SM120_RTX5090`

The focused TU was linked separately locally because CUDA 13.3 makes the current `flash` branch unrelated `ldst_matrix` test emit `st.shared.v2.b32 ..., {0,0}`, which the existing parser rejects before aggregate integration-test discovery.